### PR TITLE
fix: :bug: add favicon directly in quarto config

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,6 +7,7 @@ book:
   subtitle: "A living document for how we work in the Seedcase project"
   search:
     type: textbox
+  favicon: _extensions/seedcase-project/seedcase-theme/favicon/favicon.ico
   author:
     - "Luke W. Johnston"
     - "Signe Kirk Brødbæk"


### PR DESCRIPTION
# Description

I *think*, since this is a project of `type: book` instead of `type: seedcase-theme`, the favicon isn't added even though it's in the `_extension.yml`. 

So, this PR adds the favicon directly to the `_quarto.yml`. 

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
