### PR TITLE
build: :wrench: `normalise` reflow-mode doesn't always reflow paragraphs

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -22,7 +22,6 @@ allow-lazy-continuation = false
 # Reflow text
 [MD013]
 reflow = true
-reflow-mode = "normalize"
 
 # Fix tables and their separator row
 [MD060]

--- a/404.qmd
+++ b/404.qmd
@@ -6,6 +6,7 @@ Let's get you back to greener grounds.
 
 👉 Go to [homepage](/index.qmd).
 
-![](/_extensions/seedcase-project/seedcase-theme/images/404.svg){fig-alt="An illustration of the number 404 surrounded by trees and mountains"}
+![](/_extensions/seedcase-project/seedcase-theme/images/404.svg){fig-alt="An
+illustration of the number 404 surrounded by trees and mountains"}
 
 ## Illustration by [Storyset](https://storyset.com/web) {.appendix}

--- a/iterations/start.qmd
+++ b/iterations/start.qmd
@@ -21,7 +21,8 @@ A basic agenda could be:
 - Review and agree on the iteration aims and end date.
 - Review the list of tasks on the project board for this iteration.
 - Brainstorm and add any other issues as needed.
-  :::
+
+:::
 
 ## Before meeting
 

--- a/python/tests.qmd
+++ b/python/tests.qmd
@@ -94,12 +94,12 @@ write them. The tests should be written in Python as functions.
 
 When writing the name for the test, use this general pattern:
 
-- `test_<function-name>()`, for example `test_adding()`. Use this if
-    you only need one test for the function.
+- `test_<function-name>()`, for example `test_adding()`. Use this if you
+  only need one test for the function.
 - `test_<action>_<condition>()` or `test_<action>_<object>()`, for
-    example `test_add_twos()` or `test_error_non_numbers()`. Use this to
-    test specific actions and conditions/objects if the function has
-    multiple different actions or conditions.
+  example `test_add_twos()` or `test_error_non_numbers()`. Use this to
+  test specific actions and conditions/objects if the function has
+  multiple different actions or conditions.
 
 Tests are structured as functions that use the `assert` statement to
 check the output of the function being tested. The `assert` statement
@@ -108,14 +108,14 @@ which pytest will report on. Use the following general structure for
 tests, called **given, when, then**:
 
 1. Given: Set up the test data and any other necessary conditions. This
-    step isn't always required. This might be where you create the
-    `expected` output that you want to check against.
-2. When: Call the function or method being tested. This would return
-    the `actual` output.
+   step isn't always required. This might be where you create the
+   `expected` output that you want to check against.
+2. When: Call the function or method being tested. This would return the
+   `actual` output.
 3. Then: Check that the output of the function or method (`actual`) is
-    as expected (the `expected` output). This is where you use the
-    `assert` statement to check that the output is what you expect it to
-    be.
+   as expected (the `expected` output). This is where you use the
+   `assert` statement to check that the output is what you expect it to
+   be.
 
 This is sometimes called
 ["arrange, act, assert"](https://docs.pytest.org/en/stable/explanation/anatomy.html).

--- a/workflows/commits.qmd
+++ b/workflows/commits.qmd
@@ -51,13 +51,13 @@ fix: prevent overwriting existing raw files
 Where:
 
 - `<type>` is the type of change.
-- `[optional scope]` indicates the area of the codebase affected by
-    the change.
+- `[optional scope]` indicates the area of the codebase affected by the
+  change.
 - `<description>` is a brief summary of the change.
 - `[optional body]` provides additional context or details about the
-    change.
+  change.
 - `[optional footer(s)]` includes breaking changes or references to
-    issues/tasks.
+  issues/tasks.
 
 ::: callout-tip
 Do you want an easier time making Conventional Commits and you use VS


### PR DESCRIPTION
# Description

This mode didn't do what I thought it did, so removed it to use the default.

Needs no review.

## Checklist

- [x] Ran `just run-all`
